### PR TITLE
Makefile: Fix installation and stripping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 CC?=cc
 CFLAGS?=-std=c99 -pedantic -Wall -Os
+STRIP?=strip
+PREFIX?=/usr
 
 all:
 	${CC} ${CFLAGS} -o find-cursor find-cursor.c -lX11 -lXext -lXfixes
 
 install:
-	install --strip -o root -g root find-cursor /bin/
+	$(STRIP) find-cursor
+	install -Dm755 find-cursor $(DESTDIR)$(PREFIX)/bin/find-cursor


### PR DESCRIPTION
Found a few problems with the Makefile while reviewing it for Void Linux

- Separate stripping into another step of the package
- Conditionalize stripping the binary, distros don't like when packages do
it because they want the debug symbols included and do their own
stripping after extracting them
- use -Dm755 to create the directory (-D) and set the correct executable
mode
- respect PREFIX which can be set to /usr /usr/local and even /
- respect DESTDIR which is set by distros when they are packaging