### PR TITLE
Remove unneeded statement

### DIFF
--- a/find-cursor.c
+++ b/find-cursor.c
@@ -133,7 +133,6 @@ int main(int argc, char* argv[]) {
 			usage(argv[0]);
 			exit(1);
 		}
-	argc -= optind; 
 	argv += optind;
 
 	draw(argv[0],


### PR DESCRIPTION
Variable 'argc' is never used after this statement.