### PR TITLE
Implement `--repeat`, add a `size_cursor` hack

### DIFF
--- a/find-cursor.c
+++ b/find-cursor.c
@@ -313,8 +313,8 @@ void draw(
 				XSetForeground(display, gc, color2.pixel);
 				XDrawArc(display, window, gc,
 					size/2 - cs/2, size/2 - cs/2, // x, y position
-					cs, cs,												// Size
-					0, 360 * 64);									// Make it a full circle
+					cs, cs,                       // Size
+					0, 360 * 64);                 // Make it a full circle
 
 				// Set color back for the normal circle.
 				XSetLineAttributes(display, gc, line_width, LineSolid, CapButt, JoinBevel);
@@ -323,8 +323,8 @@ void draw(
 
 			XDrawArc(display, window, gc,
 				size/2 - cs/2, size/2 - cs/2, // x, y position
-				cs, cs,												// Size
-				0, 360 * 64);									// Make it a full circle
+				cs, cs,                       // Size
+				0, 360 * 64);                 // Make it a full circle
 
 			if (follow) {
 				XQueryPointer(display, XRootWindow(display, screen),

--- a/find-cursor.c
+++ b/find-cursor.c
@@ -69,7 +69,7 @@ void usage(char *name) {
 	printf("  The defaults:\n");
 	printf("  %s --size 320 --distance 40 --wait 400 --line-width 4 --color black\n\n", name);
 	printf("  Draw a solid circle:\n");
-	printf("  %s --size 100 --distance 1 --wait 20 --line-width 1\n", name);
+	printf("  %s --size 100 --distance 1 --wait 20 --line-width 1\n\n", name);
 	printf("  Constantly highlight the cursor:\n");
 	printf("  %s -r -c white -o -l1 -s10 -d1 -w1000 -ft\n", name);
 	printf("\n");


### PR DESCRIPTION
Hello! I discovered your StackExchange answer (https://unix.stackexchange.com/questions/183910/highlight-current-mouse-position/228674#228674) when I needed to constantly highlight the cursor (because of some VNC-like software that doesn't always show the cursor itself). I've added this repeating mode to your program.

Also, I noticed that the center of a small circle (that I used) didn't match the pointer pixel of the cursor, so I've adjusted the center a bit. Not sure if this hack would work for everyone.

For reference, I run MATE on Debian Stretch. I use the following wrapper script to run `find-cursor` (these settings are also added as an example printed by `find-cursor -h`):

```bash
#!/bin/bash

set -ex

opts=(
  # Constantly highlight the cursor:
  --repeat

  # The shrinking circle is white, the background circle is black:
  --color white
  --outline

  # The 1-pixel circle shrinks from the radius 10-1=9 to 0 with 1-pixel steps
  # (~1000*100 microseconds each), which takes ~1 second:
  --line-width 1
  --size 10
  --distance 1
  --wait 1000

  # The circles follow the cursor:
  --follow

  # This reduces the number of random white pixels on the black circle:
  --transparent
)

root=$(dirname "$0")
exec "$root"/find-cursor/find-cursor "${opts[@]}"
```