### PR TITLE
Specify the libraries after source files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,13 @@ PREFIX  ?= /usr/local
 NAME    ?= find-cursor
 
 CFLAGS  += -std=c99 -pedantic -Wall -Wextra -Wpedantic -Os
-LDFLAGS += -L/usr/lib -lX11 -lXext -lXfixes
+LDFLAGS += -L/usr/lib
+LIBS += -lX11 -lXext -lXfixes
 
 .PHONY: all clean install uninstall
 
 all:
-	${CC} ${CFLAGS} ${LDFLAGS} -o ${NAME} *.c
+	${CC} ${CFLAGS} ${LDFLAGS} -o ${NAME} *.c ${LIBS}
 
 clean:
 	rm -f ${NAME}


### PR DESCRIPTION
otherwise, if the linker links the libraries "`--as-needed`", they won't be linked at all.
